### PR TITLE
Additional cherry picks for tomviz VTK

### DIFF
--- a/Interaction/Style/vtkInteractorStyleRubberBandZoom.cxx
+++ b/Interaction/Style/vtkInteractorStyleRubberBandZoom.cxx
@@ -136,30 +136,31 @@ void vtkInteractorStyleRubberBandZoom::OnMouseMove()
 
   unsigned char *pixels = tmpPixelArray->GetPointer(0);
 
-  int min[2], max[2];
-  min[0] = startPosition[0] <= endPosition[0] ? startPosition[0] : endPosition[0];
-  min[1] = startPosition[1] <= endPosition[1] ? startPosition[1] : endPosition[1];
-  max[0] = endPosition[0] > startPosition[0] ? endPosition[0] : startPosition[0];
-  max[1] = endPosition[1] > startPosition[1] ? endPosition[1] : startPosition[1];
+  int minX = startPosition[0] <= endPosition[0] ? startPosition[0] : endPosition[0];
+  int minY = startPosition[1] <= endPosition[1] ? startPosition[1] : endPosition[1];
+  int maxX = endPosition[0] > startPosition[0] ? endPosition[0] : startPosition[0];
+  int maxY = endPosition[1] > startPosition[1] ? endPosition[1] : startPosition[1];
 
   int i;
-  for (i = min[0]; i <= max[0]; i++)
+  // Draw horizontal box lines
+  for (i = minX; i <= maxX; i++)
   {
-    pixels[3*(min[1]*size[0]+i)] = 255 ^ pixels[3*(min[1]*size[0]+i)];
-    pixels[3*(min[1]*size[0]+i)+1] = 255 ^ pixels[3*(min[1]*size[0]+i)+1];
-    pixels[3*(min[1]*size[0]+i)+2] = 255 ^ pixels[3*(min[1]*size[0]+i)+2];
-    pixels[3*(max[1]*size[0]+i)] = 255 ^ pixels[3*(max[1]*size[0]+i)];
-    pixels[3*(max[1]*size[0]+i)+1] = 255 ^ pixels[3*(max[1]*size[0]+i)+1];
-    pixels[3*(max[1]*size[0]+i)+2] = 255 ^ pixels[3*(max[1]*size[0]+i)+2];
+    pixels[3*(minY*size[0]+i)] = 255 ^ pixels[3*(minY*size[0]+i)];
+    pixels[3*(minY*size[0]+i)+1] = 255 ^ pixels[3*(minY*size[0]+i)+1];
+    pixels[3*(minY*size[0]+i)+2] = 255 ^ pixels[3*(minY*size[0]+i)+2];
+    pixels[3*(maxY*size[0]+i)] = 255 ^ pixels[3*(maxY*size[0]+i)];
+    pixels[3*(maxY*size[0]+i)+1] = 255 ^ pixels[3*(maxY*size[0]+i)+1];
+    pixels[3*(maxY*size[0]+i)+2] = 255 ^ pixels[3*(maxY*size[0]+i)+2];
   }
-  for (i = min[1]+1; i < max[1]; i++)
+  // Draw vertical box lines
+  for (i = minY+1; i < maxY; i++)
   {
-    pixels[3*(i*size[0]+min[0])] = 255 ^ pixels[3*(i*size[0]+min[0])];
-    pixels[3*(i*size[0]+min[0])+1] = 255 ^ pixels[3*(i*size[0]+min[0])+1];
-    pixels[3*(i*size[0]+min[0])+2] = 255 ^ pixels[3*(i*size[0]+min[0])+2];
-    pixels[3*(i*size[0]+max[0])] = 255 ^ pixels[3*(i*size[0]+max[0])];
-    pixels[3*(i*size[0]+max[0])+1] = 255 ^ pixels[3*(i*size[0]+max[0])+1];
-    pixels[3*(i*size[0]+max[0])+2] = 255 ^ pixels[3*(i*size[0]+max[0])+2];
+    pixels[3*(i*size[0]+minX)] = 255 ^ pixels[3*(i*size[0]+minX)];
+    pixels[3*(i*size[0]+minX)+1] = 255 ^ pixels[3*(i*size[0]+minX)+1];
+    pixels[3*(i*size[0]+minX)+2] = 255 ^ pixels[3*(i*size[0]+minX)+2];
+    pixels[3*(i*size[0]+maxX)] = 255 ^ pixels[3*(i*size[0]+maxX)];
+    pixels[3*(i*size[0]+maxX)+1] = 255 ^ pixels[3*(i*size[0]+maxX)+1];
+    pixels[3*(i*size[0]+maxX)+2] = 255 ^ pixels[3*(i*size[0]+maxX)+2];
   }
 
   this->Interactor->GetRenderWindow()->SetPixelData(0, 0, size[0]-1, size[1]-1, pixels, 1);

--- a/Interaction/Style/vtkInteractorStyleRubberBandZoom.cxx
+++ b/Interaction/Style/vtkInteractorStyleRubberBandZoom.cxx
@@ -15,14 +15,13 @@
 #include "vtkInteractorStyleRubberBandZoom.h"
 
 #include "vtkCamera.h"
+#include "vtkMath.h"
 #include "vtkObjectFactory.h"
 #include "vtkRenderWindow.h"
 #include "vtkRenderWindowInteractor.h"
 #include "vtkRenderer.h"
 #include "vtkUnsignedCharArray.h"
 #include "vtkVectorOperators.h"
-
-#include <algorithm>
 
 namespace impl
 {
@@ -138,15 +137,15 @@ void vtkInteractorStyleRubberBandZoom::OnMouseMove()
 
   unsigned char *pixels = tmpPixelArray->GetPointer(0);
 
-  int minX = std::min(startPosition[0], endPosition[0]);
-  int minY = std::min(startPosition[1], endPosition[1]);
-  int maxX = std::max(startPosition[0], endPosition[0]);
-  int maxY = std::max(startPosition[1], endPosition[1]);
+  int minX = vtkMath::Min(startPosition[0], endPosition[0]);
+  int minY = vtkMath::Min(startPosition[1], endPosition[1]);
+  int maxX = vtkMath::Max(startPosition[0], endPosition[0]);
+  int maxY = vtkMath::Max(startPosition[1], endPosition[1]);
 
-  int clampedMinX = std::max(minX, 0);
-  int clampedMaxX = std::min(maxX, size[0]-1);
-  int clampedMinY = std::max(minY, 0);
-  int clampedMaxY = std::min(maxY, size[1]-1);
+  int clampedMinX = vtkMath::Max(minX, 0);
+  int clampedMaxX = vtkMath::Min(maxX, size[0]-1);
+  int clampedMinY = vtkMath::Max(minY, 0);
+  int clampedMaxY = vtkMath::Min(maxY, size[1]-1);
 
   // Draw zoom box
   // Draw bottom horizontal line

--- a/Rendering/Volume/Testing/Cxx/TestGPURayCastTransfer2D.cxx
+++ b/Rendering/Volume/Testing/Cxx/TestGPURayCastTransfer2D.cxx
@@ -153,6 +153,10 @@ int TestGPURayCastTransfer2D(int argc, char* argv[])
 
   renWin->Render();
 
+  // Simulate modification of 2D transfer function to test for shader issues
+  tf2d->Modified();
+  renWin->Render();
+
   int retVal = vtkTesting::Test(argc, argv, renWin, 90);
   if (retVal == vtkRegressionTester::DO_INTERACTOR)
     {

--- a/Rendering/VolumeOpenGL2/vtkVolumeInputHelper.cxx
+++ b/Rendering/VolumeOpenGL2/vtkVolumeInputHelper.cxx
@@ -374,11 +374,13 @@ void vtkVolumeInputHelper::CreateTransferFunction1D(vtkRenderer* ren, const int 
   this->RGBTablesMap.clear();
   this->GradientOpacityTablesMap.clear();
 
+  std::ostringstream idx;
+  idx << index;
+
+  this->GradientCacheName = "g_gradients_" + idx.str();
+
   for (int i = 0; i < numActiveLuts; ++i)
   {
-    std::ostringstream idx;
-    idx << index;
-
     std::ostringstream comp;
     comp << "[" << i << "]";
 
@@ -392,7 +394,6 @@ void vtkVolumeInputHelper::CreateTransferFunction1D(vtkRenderer* ren, const int 
     {
       this->GradientOpacityTablesMap[i] =
         "in_gradientTransferFunc_" + idx.str() + comp.str();
-      this->GradientCacheName += "g_gradients_" + idx.str();
     }
   }
 
@@ -411,16 +412,17 @@ void vtkVolumeInputHelper::CreateTransferFunction2D(vtkRenderer* ren,
     vtkSmartPointer<vtkOpenGLTransferFunctions2D>::New();
   this->TransferFunctions2D->Create(num);
 
+  std::ostringstream idx;
+  idx << index;
+
+  this->GradientCacheName = "g_gradients_" + idx.str();
+
   for (unsigned int i = 0; i < num; i++)
   {
-    std::ostringstream idx;
-    idx << index;
-
     std::ostringstream comp;
     comp << "[" << i << "]";
 
     this->TransferFunctions2DMap[i] = "in_transfer2D_" + idx.str() + comp.str();
-    this->GradientCacheName += "g_gradients_" + idx.str();
   }
 
   this->LutInit.Modified();


### PR DESCRIPTION
These commits fix a crash when using the Zoom to Box feature in tomviz (and ParaView) when the mouse cursor goes outside the render view.